### PR TITLE
fix deprecated use of value for `with_items`

### DIFF
--- a/tasks/filters.yml
+++ b/tasks/filters.yml
@@ -15,7 +15,7 @@
     owner:  "{{ item.config.filter.conf.owner | default(omit) }}"
     group:  "{{ item.config.filter.conf.group | default(omit) }}"
     mode:   "{{ item.config.filter.conf.mode | default(omit) }}"
-  with_items: fail2ban_jails
+  with_items: "{{fail2ban_jails}}"
   notify:
     - restart fail2ban
 ...


### PR DESCRIPTION
fix deprecation warning/error
`[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{fail2ban_jails}}').`