### PR TITLE
add use of `become`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+fail2ban_start_after_installation: true
 fail2ban_pkg_install_latest: no
 fail2ban_become: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 fail2ban_pkg_install_latest: no
+fail2ban_become: false
 
 fail2ban_config_dir:          '/etc/fail2ban'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-fail2ban_start_after_installation: true
+# fail2ban_start_after_installation: true
 fail2ban_pkg_install_latest: no
 fail2ban_become: false
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,5 @@
   service:
     name:  fail2ban
     state: restarted
+  become: "{{ fail2ban_become }}"
 ...

--- a/tasks/actions.yml
+++ b/tasks/actions.yml
@@ -6,4 +6,5 @@
     group:  "{{ fail2ban_action_group }}"
     mode:   "{{ fail2ban_action_mode }}"
     state:  directory
+  become: true
 ...

--- a/tasks/actions.yml
+++ b/tasks/actions.yml
@@ -6,5 +6,5 @@
     group:  "{{ fail2ban_action_group }}"
     mode:   "{{ fail2ban_action_mode }}"
     state:  directory
-  become: true
+  become: "{{ fail2ban_become }}"
 ...

--- a/tasks/distros/centos.yml
+++ b/tasks/distros/centos.yml
@@ -15,4 +15,5 @@
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
   notify:
     - restart fail2ban
+  become: true
 ...

--- a/tasks/distros/centos.yml
+++ b/tasks/distros/centos.yml
@@ -19,7 +19,7 @@
   yum:
     name: fail2ban
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
-  notify:
-    - restart fail2ban
+  # notify:
+  #   - restart fail2ban
   become: "{{ fail2ban_become }}"
 ...

--- a/tasks/distros/centos.yml
+++ b/tasks/distros/centos.yml
@@ -9,11 +9,17 @@
     fail2ban_distro_auth_log: "{{ fail2ban_centos_auth_log }}"
   when: fail2ban_distro_auth_log is not defined
 
+- name: Install EPEL release via yum
+  yum:
+    name: epel-release
+    state: present
+  become: "{{ fail2ban_become }}"
+
 - name: Install fail2ban via yum
   yum:
-    name:  fail2ban
+    name: fail2ban
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
   notify:
     - restart fail2ban
-  become: true
+  become: "{{ fail2ban_become }}"
 ...

--- a/tasks/distros/centos.yml
+++ b/tasks/distros/centos.yml
@@ -19,7 +19,7 @@
   yum:
     name: fail2ban
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
-  # notify:
-  #   - restart fail2ban
+  notify:
+    - restart fail2ban
   become: "{{ fail2ban_become }}"
 ...

--- a/tasks/distros/debian.yml
+++ b/tasks/distros/debian.yml
@@ -15,4 +15,5 @@
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
   notify:
     - restart fail2ban
+  become: true
 ...

--- a/tasks/distros/debian.yml
+++ b/tasks/distros/debian.yml
@@ -13,7 +13,7 @@
   apt:
     name: fail2ban
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
-  notify:
-    - restart fail2ban
+  # notify:
+  #   - restart fail2ban
   become: "{{ fail2ban_become }}"
 ...

--- a/tasks/distros/debian.yml
+++ b/tasks/distros/debian.yml
@@ -13,7 +13,7 @@
   apt:
     name: fail2ban
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
-  # notify:
-  #   - restart fail2ban
+  notify:
+    - restart fail2ban
   become: "{{ fail2ban_become }}"
 ...

--- a/tasks/distros/debian.yml
+++ b/tasks/distros/debian.yml
@@ -15,5 +15,5 @@
     state: "{{ 'latest' if fail2ban_pkg_install_latest else 'present' }}"
   notify:
     - restart fail2ban
-  become: true
+  become: "{{ fail2ban_become }}"
 ...

--- a/tasks/filters.yml
+++ b/tasks/filters.yml
@@ -17,7 +17,7 @@
     group:  "{{ item.config.filter.conf.group | default(omit) }}"
     mode:   "{{ item.config.filter.conf.mode | default(omit) }}"
   with_items: "{{fail2ban_jails}}"
-  # notify:
-  #   - restart fail2ban
+  notify:
+    - restart fail2ban
   become: "{{ fail2ban_become }}"
 ...

--- a/tasks/filters.yml
+++ b/tasks/filters.yml
@@ -17,7 +17,7 @@
     group:  "{{ item.config.filter.conf.group | default(omit) }}"
     mode:   "{{ item.config.filter.conf.mode | default(omit) }}"
   with_items: "{{fail2ban_jails}}"
-  notify:
-    - restart fail2ban
+  # notify:
+  #   - restart fail2ban
   become: "{{ fail2ban_become }}"
 ...

--- a/tasks/filters.yml
+++ b/tasks/filters.yml
@@ -7,6 +7,7 @@
     group:  "{{ fail2ban_filter_group | default('root') }}"
     mode:   "{{ fail2ban_filter_mode | default('0600') }}"
     state:  directory
+  become: true
 
 - name: Copy the correct filters into place
   template:
@@ -18,4 +19,5 @@
   with_items: "{{fail2ban_jails}}"
   notify:
     - restart fail2ban
+  become: true
 ...

--- a/tasks/filters.yml
+++ b/tasks/filters.yml
@@ -7,7 +7,7 @@
     group:  "{{ fail2ban_filter_group | default('root') }}"
     mode:   "{{ fail2ban_filter_mode | default('0600') }}"
     state:  directory
-  become: true
+  become: "{{ fail2ban_become }}"
 
 - name: Copy the correct filters into place
   template:
@@ -19,5 +19,5 @@
   with_items: "{{fail2ban_jails}}"
   notify:
     - restart fail2ban
-  become: true
+  become: "{{ fail2ban_become }}"
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,8 +23,8 @@
     owner:  "{{ fail2ban_localjail_owner }}"
     group:  "{{ fail2ban_localjail_group }}"
     mode:   "{{ fail2ban_localjail_mode }}"
-  notify:
-    - restart fail2ban
+  # notify:
+  #   - restart fail2ban
   become: "{{ fail2ban_become }}"
 
 - name: Start fail2ban

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,4 +27,14 @@
     - restart fail2ban
   become: "{{ fail2ban_become }}"
 
+- name: Start fail2ban
+  service:
+    name:  "{{ jumpcloud_agent_service }}"
+    state: started
+  become: "{{ fail2ban_become }}"
+  ignore_errors: true
+  when: fail2ban_start_after_installation
+
+
+
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,17 +23,17 @@
     owner:  "{{ fail2ban_localjail_owner }}"
     group:  "{{ fail2ban_localjail_group }}"
     mode:   "{{ fail2ban_localjail_mode }}"
-  # notify:
-  #   - restart fail2ban
+  notify:
+    - restart fail2ban
   become: "{{ fail2ban_become }}"
 
-- name: Start fail2ban
-  service:
-    name:  "{{ jumpcloud_agent_service }}"
-    state: started
-  become: "{{ fail2ban_become }}"
-  ignore_errors: true
-  when: fail2ban_start_after_installation
+# - name: Start fail2ban
+#   service:
+#     name:  "{{ jumpcloud_agent_service }}"
+#     state: started
+#   become: "{{ fail2ban_become }}"
+#   ignore_errors: true
+#   when: fail2ban_start_after_installation
 
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,6 @@
     mode:   "{{ fail2ban_localjail_mode }}"
   notify:
     - restart fail2ban
-  become: true
+  become: "{{ fail2ban_become }}"
 
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,5 +25,6 @@
     mode:   "{{ fail2ban_localjail_mode }}"
   notify:
     - restart fail2ban
+  become: true
 
 ...


### PR DESCRIPTION
The use of `become` is needed if you are provisioning using an Admin user (enabled to run `sudo`), especially useful when root ssh access is disallowed

An example case is when re-provisioning a vm which had the `root` access disabled after the first provisioning and had access managed via JumpCloud tags/users